### PR TITLE
Fix Xcode Build Warnings

### DIFF
--- a/Samba Action Calculator/SACAction.h
+++ b/Samba Action Calculator/SACAction.h
@@ -26,7 +26,7 @@
 - (id)initWithValues:(NSInteger)at
              minRoll:(NSInteger)mn
            forPlayer:(SACPlayer *)player
-             atIndex:(int)index;
+             atIndex:(NSInteger)index;
 
 - (NSMutableString *)interfaceText;
 

--- a/Samba Action Calculator/SACAction.m
+++ b/Samba Action Calculator/SACAction.m
@@ -15,7 +15,7 @@
 - (id)initWithValues:(NSInteger)at
              minRoll:(NSInteger)mn
            forPlayer:(SACPlayer *)player
-             atIndex:(int)index {
+             atIndex:(NSInteger)index {
     // Call the NSObject's init method
     self = [super init];
     
@@ -88,7 +88,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<Stored Action of type: %d with a min. roll of %d>", action_type, min_roll];
+    return [NSString stringWithFormat:@"<Stored Action of type: %ld with a min. roll of %ld>", (long)action_type, (long)min_roll];
 }
 
 - (NSMutableString *)interfaceText {
@@ -96,23 +96,23 @@
     switch (action_type) {
         case 1:
             // Dodge Action
-            [desc appendFormat:@"%d+ Dodge", min_roll];
+            [desc appendFormat:@"%ld+ Dodge", (long)min_roll];
         break;
         case 2:
             // Pick up Action
-            [desc appendFormat:@"%d+ Pick up", min_roll];
+            [desc appendFormat:@"%ld+ Pick up", min_roll];
         break;
         case 3:
             // GFI Action
-            [desc appendFormat:@"%d+ GFI", min_roll];
+            [desc appendFormat:@"%ld+ GFI", min_roll];
         break;
         case 4:
             // Pass Action
-            [desc appendFormat:@"%d+ Pass", min_roll];
+            [desc appendFormat:@"%ld+ Pass", min_roll];
         break;
         case 5:
             // Catch Action
-            [desc appendFormat:@"%d+ Catch", min_roll];
+            [desc appendFormat:@"%ld+ Catch", min_roll];
         break;
         case 6:
             // Block Action
@@ -120,7 +120,7 @@
         break;
         default:
             // Generic Action
-            [desc appendFormat:@"%d+ Action", min_roll];
+            [desc appendFormat:@"%ld+ Action", min_roll];
         break;
     }
     if(hasPro) [desc appendFormat:@"*"];

--- a/Samba Action Calculator/SACAppDelegate.h
+++ b/Samba Action Calculator/SACAppDelegate.h
@@ -17,6 +17,6 @@
 + (SACAppDelegate *)sharedAppDelegate;
 
 - (void)savePlayer:(SACPlayer *)player;
-- (void)deletePlayer:(int)playerIndex;
+- (void)deletePlayer:(NSInteger)playerIndex;
 
 @end

--- a/Samba Action Calculator/SACBlockAction.h
+++ b/Samba Action Calculator/SACBlockAction.h
@@ -17,7 +17,7 @@
 - (id)initWithValues:(NSInteger)at
              minRoll:(NSInteger)mn
            forPlayer:(SACPlayer *)player
-             atIndex:(int)index
+             atIndex:(NSInteger)index
         successArr:(NSArray*)sa;
 
 - (NSMutableString*) getDiceDescription;

--- a/Samba Action Calculator/SACBlockAction.m
+++ b/Samba Action Calculator/SACBlockAction.m
@@ -15,10 +15,10 @@
 - (id)initWithValues:(NSInteger)at
              minRoll:(NSInteger)mn
            forPlayer:(SACPlayer *)player
-             atIndex:(int)index
+             atIndex:(NSInteger)index
           successArr:(NSArray*)sa {
     // Call the superclass's initializer
-    self = [super initWithValues:at minRoll:mn forPlayer:player atIndex:(int)index];
+    self = [super initWithValues:at minRoll:mn forPlayer:player atIndex:index];
     
     if(self) {
         numSuccess = sa;
@@ -89,12 +89,12 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<Stored Block Action of type: %d with %d dice. Successful with %@>", [self action_type], [self numDice], [self getDiceDescription]];
+    return [NSString stringWithFormat:@"<Stored Block Action of type: %ld with %ld dice. Successful with %@>", (long)[self action_type], (long)[self numDice], [self getDiceDescription]];
 }
 
 - (NSMutableString *)interfaceText {
     NSMutableString *desc = [[NSMutableString alloc] init];
-    [desc appendFormat:@"%dd Block", self.numDice];
+    [desc appendFormat:@"%ldd Block", (long)self.numDice];
     if(self.hasPro) [desc appendFormat:@"*"];
     return desc;
 }

--- a/Samba Action Calculator/SACFullSequence.h
+++ b/Samba Action Calculator/SACFullSequence.h
@@ -19,13 +19,13 @@
 
 - (void) addAction:(SACAction *) action;
 
-- (void) removeAction:(int) index;
+- (void) removeAction:(NSInteger) index;
 
 - (void) clearActions;
 
 - (float) getProbaReroll:(BOOL)teamRerollLeft;
 
-- (float) getProbaAction:(int)n
+- (float) getProbaAction:(NSInteger)n
                   teamRR:(BOOL)trLeft
                  dodgeRR:(BOOL)drLeft
                     sfRR:(BOOL)sfrLeft

--- a/Samba Action Calculator/SACFullSequence.m
+++ b/Samba Action Calculator/SACFullSequence.m
@@ -40,7 +40,7 @@
      */
 }
 
-- (void) removeAction:(int) index {
+- (void) removeAction:(NSInteger) index {
     // remove the action from the array
     [sequence removeObjectAtIndex:index];
 }
@@ -53,7 +53,7 @@
     return [self getProbaAction:0 teamRR:teamRerollLeft dodgeRR:YES sfRR:YES proRR:YES];
 }
 
-- (float) getProbaAction:(int)n
+- (float) getProbaAction:(NSInteger)n
                   teamRR:(BOOL)trLeft
                  dodgeRR:(BOOL)drLeft
                     sfRR:(BOOL)sfrLeft

--- a/Samba Action Calculator/SACPassAction.h
+++ b/Samba Action Calculator/SACPassAction.h
@@ -18,7 +18,7 @@
 - (id)initWithValues:(NSInteger)at
              minRoll:(NSInteger)mn
            forPlayer:(SACPlayer *)player
-             atIndex:(int)index
+             atIndex:(NSInteger)index
         canIntercept:(NSInteger)i
               hasPro:(BOOL)p
             hasCatch:(BOOL)c;

--- a/Samba Action Calculator/SACPassAction.m
+++ b/Samba Action Calculator/SACPassAction.m
@@ -15,12 +15,12 @@
 - (id)initWithValues:(NSInteger)at
              minRoll:(NSInteger)mn
            forPlayer:(SACPlayer *)player
-             atIndex:(int)index
+             atIndex:(NSInteger)index
         canIntercept:(NSInteger)i
               hasPro:(BOOL)p
             hasCatch:(BOOL)c {
     // Call the superclass's initializer
-    self = [super initWithValues:at minRoll:mn forPlayer:player atIndex:(int)index];
+    self = [super initWithValues:at minRoll:mn forPlayer:player atIndex:index];
     
     if(self) {
         // Add the pass params
@@ -64,14 +64,14 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<Stored Pass Action of type: %d with a min. roll of %d. Can be intercepted: (%d) with Pro (%s) and Catch (%s)>", [self action_type], [self min_roll], [self interception], [self withPro] ? "true" : "false", [self withCatch] ? "true" : "false"];
+    return [NSString stringWithFormat:@"<Stored Pass Action of type: %ld with a min. roll of %ld. Can be intercepted: (%ld) with Pro (%s) and Catch (%s)>", (long)[self action_type], (long)[self min_roll], (long)[self interception], [self withPro] ? "true" : "false", [self withCatch] ? "true" : "false"];
 }
 
 - (NSMutableString *)interfaceText {
     NSMutableString *desc = [[NSMutableString alloc] init];
-    [desc appendFormat:@"%d+ Pass", self.min_roll];
+    [desc appendFormat:@"%ld+ Pass", (long)self.min_roll];
     if(interception > 0) {
-        [desc appendFormat:@" (NSInteger %d+", interception];
+        [desc appendFormat:@" (NSInteger %ld+", (long)interception];
         if(withPro) [desc appendFormat:@",p"];
         if(withCatch) [desc appendFormat:@",c"];
         [desc appendFormat:@")"];

--- a/Samba Action Calculator/SACPlayerChangeViewController.h
+++ b/Samba Action Calculator/SACPlayerChangeViewController.h
@@ -12,7 +12,7 @@
 @protocol sendNewActivePlayer <NSObject>
 @required
 
-- (void)changeActivePlayer:(int)playerIndex;
+- (void)changeActivePlayer:(NSInteger)playerIndex;
 
 @end
 

--- a/Samba Action Calculator/SACPlayerChangeViewController.m
+++ b/Samba Action Calculator/SACPlayerChangeViewController.m
@@ -52,7 +52,7 @@
 
 
 - (IBAction)cancelPlayerChange:(id)sender {
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:NULL];
 }
 
 - (IBAction)changePlayer:(id)sender {

--- a/Samba Action Calculator/SACPlayerFormController.m
+++ b/Samba Action Calculator/SACPlayerFormController.m
@@ -35,7 +35,7 @@
 }
 
 - (IBAction)cancelPlayerSave:(id)sender {
-    [self dismissModalViewControllerAnimated:YES];
+    [self dismissViewControllerAnimated:YES completion:NULL];
 }
 
 - (IBAction)savePlayer:(id)sender {
@@ -88,7 +88,7 @@
         [lonerSwitch setOn:0];
         
         // Close the view
-        [self dismissModalViewControllerAnimated:YES];
+        [self dismissViewControllerAnimated:YES completion:NULL];
     }
 }
 

--- a/Samba Action Calculator/SACSequenceViewController.h
+++ b/Samba Action Calculator/SACSequenceViewController.h
@@ -45,15 +45,15 @@
 @property NSInteger prevButton;
 @property (nonatomic, strong) UIViewController *changePlayerVC;
 
-- (void)activatePlayer:(int)playerIndex;
+- (void)activatePlayer:(NSInteger)playerIndex;
 
 - (IBAction)addPlayerAction:(UIButton*)sender;
 
-- (void)showAction:(SACAction *)action atPosition:(int)pos;
+- (void)showAction:(SACAction *)action atPosition:(NSInteger)pos;
 
 - (IBAction)removePlayerAction:(UITapGestureRecognizer*)recognizer;
 
-- (void)removePlayer:(int)actionIndex;
+- (void)removePlayer:(NSInteger)actionIndex;
 
 - (IBAction)togglePro:(UIButton*)sender;
 
@@ -61,7 +61,7 @@
 
 - (void)showOdds;
 
-- (void)adjustViewHeight:(int)actionRows;
+- (void)adjustViewHeight:(NSInteger)actionRows;
 
 - (IBAction)slidePhoneInterface:(UIButton*)sender;
 

--- a/Samba Action Calculator/SACSequenceViewController.m
+++ b/Samba Action Calculator/SACSequenceViewController.m
@@ -19,7 +19,7 @@
 
 @synthesize activePlayer, currentPlayerIndex, actionSequence, scrollView, nameLabel, skillsLabel, noRRLabel, yesRRLabel, interceptSeg, usePro, useCatch, blockSeg, skillsView, probaView, phoneBottomContainer, isopen, phoneSlideOutView, phoneActionBtn, phoneSeg, activeButton, prevButton, changePlayerVC;
 
-- (void)activatePlayer:(int)playerIndex {
+- (void)activatePlayer:(NSInteger)playerIndex {
     _appDelegate = [SACAppDelegate sharedAppDelegate];
     self.activePlayer = [_appDelegate.players objectAtIndex:playerIndex];
     currentPlayerIndex = playerIndex;
@@ -32,7 +32,7 @@
     }
 }
 
-- (void)changeActivePlayer:(int)playerIndex {
+- (void)changeActivePlayer:(NSInteger)playerIndex {
     // first we need to check if the player has changed at all
     if(playerIndex != currentPlayerIndex) {
         [self activatePlayer:playerIndex];
@@ -49,7 +49,7 @@
             [self.skillsLabel sizeToFit];
         }
     }
-    [changePlayerVC dismissModalViewControllerAnimated:YES];
+    [changePlayerVC dismissViewControllerAnimated:YES completion:NULL];
 }
 
 - (IBAction)addPlayerAction:(UIButton*)sender {
@@ -242,7 +242,7 @@
     [self showOdds];
 }
 
-- (void) showAction:(SACAction *) action atPosition:(int)pos {
+- (void) showAction:(SACAction *) action atPosition:(NSInteger)pos {
     // show the action in the interface
     NSInteger row;
     NSInteger col;
@@ -342,7 +342,7 @@
     }
 }
 
-- (void)removePlayer:(int)actionIndex {
+- (void)removePlayer:(NSInteger)actionIndex {
     //NSInteger actionIndex = sender.tag-1;
     NSInteger rows;
     //NSLog(@"Remove action at index %d", actionIndex);
@@ -453,7 +453,7 @@
     self.yesRRLabel.text = [NSString stringWithFormat:@"%.3f%%", probYesrr];
 }
 
-- (void) adjustViewHeight:(int)actionRows {
+- (void) adjustViewHeight:(NSInteger)actionRows {
     // adjust the view port height
     CGRect frame = [skillsView frame];
     CGRect probaFrame = [probaView frame];


### PR DESCRIPTION
Xcode was reporting several warnings, so have cleared them by:
- Replaces deprecated dismiss methods
- Fixes string formatting warnings using Xcode's auto-fix
- Replacing `int` with `NSInteger`